### PR TITLE
US13.Section_Front_Back

### DIFF
--- a/client/src/components/Home/FilmSection.jsx
+++ b/client/src/components/Home/FilmSection.jsx
@@ -10,21 +10,19 @@ export default function FilmSection() {
       return releaseYear >= startYear && releaseYear <= endYear;
     });
 
-    const twentyTwentyFilms = filterfilmsByDecade(allFilms, 2020, 2024);
-    const twentyTensFilms = filterfilmsByDecade(allFilms, 2010, 2019);
-    const twentiesFilms = filterfilmsByDecade(allFilms, 2000, 2009);
-    const ninetiesFilms = filterfilmsByDecade(allFilms, 1990, 1999);
-    const eightiesFilms = filterfilmsByDecade(allFilms, 1980, 1989);
-    const seventiesFilms = filterfilmsByDecade(allFilms, 1970, 1979);
+  const twentyTwentyFilms = filterfilmsByDecade(allFilms, 2020, 2024);
+  const twentyTensFilms = filterfilmsByDecade(allFilms, 2010, 2019);
+  const twentiesFilms = filterfilmsByDecade(allFilms, 2000, 2009);
+  const ninetiesFilms = filterfilmsByDecade(allFilms, 1990, 1999);
+  const eightiesFilms = filterfilmsByDecade(allFilms, 1980, 1989);
+  const seventiesFilms = filterfilmsByDecade(allFilms, 1970, 1979);
 
-  const [currentTwentyTwenty, handleTwentyTwentyNext, handleTwentyTwentyPrev] = useCarousel(
-    twentyTwentyFilms.length
-    );
+  const [currentTwentyTwenty, handleTwentyTwentyNext, handleTwentyTwentyPrev] =
+    useCarousel(twentyTwentyFilms.length);
 
-  const [currentTwentyTens, handleTwentyTensNext, handleTwentyTensPrev] = useCarousel(
-    twentyTensFilms.length
-    );
-    
+  const [currentTwentyTens, handleTwentyTensNext, handleTwentyTensPrev] =
+    useCarousel(twentyTensFilms.length);
+
   const [currentTwenty, handleTwentyNext, handleTwentyPrev] = useCarousel(
     twentiesFilms.length
   );
@@ -40,14 +38,13 @@ export default function FilmSection() {
 
   return (
     <>
-    
       <FilmCarousel
         films={seventiesFilms}
         currentIndex={currentSeventy}
         handleNext={handleSeventyNext}
         handlePrev={handleSeventyPrev}
         title="Années 1970"
-      />  
+      />
 
       <FilmCarousel
         films={eightiesFilms}

--- a/client/src/components/Home/FilmSection.jsx
+++ b/client/src/components/Home/FilmSection.jsx
@@ -10,11 +10,21 @@ export default function FilmSection() {
       return releaseYear >= startYear && releaseYear <= endYear;
     });
 
-  const twentiesFilms = filterfilmsByDecade(allFilms, 2000, 2009);
-  const ninetiesFilms = filterfilmsByDecade(allFilms, 1990, 1999);
-  const eightiesFilms = filterfilmsByDecade(allFilms, 1980, 1989);
-  const seventiesFilms = filterfilmsByDecade(allFilms, 1970, 1979);
+    const twentyTwentyFilms = filterfilmsByDecade(allFilms, 2020, 2024);
+    const twentyTensFilms = filterfilmsByDecade(allFilms, 2010, 2019);
+    const twentiesFilms = filterfilmsByDecade(allFilms, 2000, 2009);
+    const ninetiesFilms = filterfilmsByDecade(allFilms, 1990, 1999);
+    const eightiesFilms = filterfilmsByDecade(allFilms, 1980, 1989);
+    const seventiesFilms = filterfilmsByDecade(allFilms, 1970, 1979);
 
+  const [currentTwentyTwenty, handleTwentyTwentyNext, handleTwentyTwentyPrev] = useCarousel(
+    twentyTwentyFilms.length
+    );
+
+  const [currentTwentyTens, handleTwentyTensNext, handleTwentyTensPrev] = useCarousel(
+    twentyTensFilms.length
+    );
+    
   const [currentTwenty, handleTwentyNext, handleTwentyPrev] = useCarousel(
     twentiesFilms.length
   );
@@ -30,33 +40,53 @@ export default function FilmSection() {
 
   return (
     <>
-      <FilmCarousel
-        films={twentiesFilms}
-        currentIndex={currentTwenty}
-        handleNext={handleTwentyNext}
-        handlePrev={handleTwentyPrev}
-        title="Années 20"
-      />
-      <FilmCarousel
-        films={ninetiesFilms}
-        currentIndex={currentNinety}
-        handleNext={handleNinetyNext}
-        handlePrev={handleNinetyPrev}
-        title="Années 90"
-      />
-      <FilmCarousel
-        films={eightiesFilms}
-        currentIndex={currentEighty}
-        handleNext={handleEightyNext}
-        handlePrev={handleEightyPrev}
-        title="Années 80"
-      />
+    
       <FilmCarousel
         films={seventiesFilms}
         currentIndex={currentSeventy}
         handleNext={handleSeventyNext}
         handlePrev={handleSeventyPrev}
-        title="Années 70"
+        title="Années 1970"
+      />  
+
+      <FilmCarousel
+        films={eightiesFilms}
+        currentIndex={currentEighty}
+        handleNext={handleEightyNext}
+        handlePrev={handleEightyPrev}
+        title="Années 1980"
+      />
+
+      <FilmCarousel
+        films={ninetiesFilms}
+        currentIndex={currentNinety}
+        handleNext={handleNinetyNext}
+        handlePrev={handleNinetyPrev}
+        title="Années 1990"
+      />
+
+      <FilmCarousel
+        films={twentiesFilms}
+        currentIndex={currentTwenty}
+        handleNext={handleTwentyNext}
+        handlePrev={handleTwentyPrev}
+        title="Années 2000"
+      />
+
+      <FilmCarousel
+        films={twentyTensFilms}
+        currentIndex={currentTwentyTens}
+        handleNext={handleTwentyTensNext}
+        handlePrev={handleTwentyTensPrev}
+        title="Années 2010"
+      />
+
+      <FilmCarousel
+        films={twentyTwentyFilms}
+        currentIndex={currentTwentyTwenty}
+        handleNext={handleTwentyTwentyNext}
+        handlePrev={handleTwentyTwentyPrev}
+        title="Années 2020"
       />
     </>
   );

--- a/client/src/components/Home/FilmSectionCarousel.jsx
+++ b/client/src/components/Home/FilmSectionCarousel.jsx
@@ -28,7 +28,7 @@ export default function FilmCarousel({
     <>
       <h1 className={styles.sectionFilmTitle}>{title}</h1>
       <div className={styles.sectionFilm}>
-        {films.slice(currentIndex, currentIndex + 2).map((film) => (
+        {films.slice(currentIndex, currentIndex + 5).map((film) => (
           <div key={film.id}>
             <div className={styles.divSize}>
               <Link to={`/bandeannonce/${film.id}/`}>

--- a/client/src/components/Home/filmsection.module.css
+++ b/client/src/components/Home/filmsection.module.css
@@ -1,6 +1,8 @@
 .sectionFilmTitle {
   font-family: var(--font-regular);
   color: var(--main-color);
+  margin-left: 2.5rem;
+  margin-right: 2.5rem;
   border-bottom: solid 2px var(--fourth-color);
 }
 


### PR DESCRIPTION
En tant qu’utilisateur, je peux avoir accès à une section qui présente plusieurs affiches de films et lorsque je clique sur une affiche de film qui se trouve dans une section, je suis renvoyée à la videopage du film associé

DONE :

Les sections sont regroupées par année (date de sortie de film)

Connexion back et front

A FAIRE :

Modification carrousel (plus d’images, CSS, ajout de section 2010 et 2020, changement d’ordre par année)

Poker Planning : 8/10